### PR TITLE
chore: aws lambda: phone home retries

### DIFF
--- a/scripts/aws/phonehome.py
+++ b/scripts/aws/phonehome.py
@@ -40,6 +40,7 @@ def lambda_handler(event, context):
             last_error = f"HTTP {response.status}: {response.data}"
             print(f"Attempt {attempt + 1}/{MAX_RETRIES} failed: {last_error}")
         except Exception as e:
+            # It's OK if notifying Nuon fails on deletion
             last_error = str(e)
             print(f"Attempt {attempt + 1}/{MAX_RETRIES} error: {last_error}")
 

--- a/scripts/aws/phonehome.py
+++ b/scripts/aws/phonehome.py
@@ -1,37 +1,55 @@
 import json
+import time
 
 import urllib3
 import cfnresponse
 
 http = urllib3.PoolManager()
 
+MAX_RETRIES = 3
+BASE_DELAY = 1
+
 
 def lambda_handler(event, context):
     props = event["ResourceProperties"]
-    
+
     # Start with all fields from the event
     data = event.copy()
     # Remove ResourceProperties since we'll flatten those separately
     props = data.pop("ResourceProperties", None)
 
     props["request_type"] = event["RequestType"]
-    
+
     encoded_data = json.dumps(props).encode("utf-8")
     url = props["url"]
 
-    try:
-        response = http.request(
-            "POST",
-            url,
-            body=encoded_data,
-            headers={"Content-Type": "application/json"},
-        )
-        print("Response: ", response.data)
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = http.request(
+                "POST",
+                url,
+                body=encoded_data,
+                headers={"Content-Type": "application/json"},
+            )
+            if 200 <= response.status < 300:
+                print("Response: ", response.data)
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                return
+
+            last_error = f"HTTP {response.status}: {response.data}"
+            print(f"Attempt {attempt + 1}/{MAX_RETRIES} failed: {last_error}")
+        except Exception as e:
+            last_error = str(e)
+            print(f"Attempt {attempt + 1}/{MAX_RETRIES} error: {last_error}")
+
+        if attempt < MAX_RETRIES - 1:
+            delay = BASE_DELAY * (2 ** attempt)
+            print(f"Retrying in {delay}s...")
+            time.sleep(delay)
+
+    print("All retries exhausted. Error: ", last_error)
+    if event["RequestType"] in ["Create", "Update"]:
+        cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": last_error})
+    else:
         cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-    except Exception as e:
-        print("Error: ", str(e))
-        # It's OK if notifying Nuon fails on deletion
-        if event["RequestType"] in ["Create", "Update"]:
-            cfnresponse.send(event, context, cfnresponse.FAILED, {"Error": str(e)})
-        else:
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, {})

--- a/scripts/aws/phonehome.py
+++ b/scripts/aws/phonehome.py
@@ -6,8 +6,8 @@ import cfnresponse
 
 http = urllib3.PoolManager()
 
-MAX_RETRIES = 3
-BASE_DELAY = 1
+MAX_RETRIES = 5
+BASE_DELAY = 1.75
 
 
 def lambda_handler(event, context):
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
             print(f"Attempt {attempt + 1}/{MAX_RETRIES} error: {last_error}")
 
         if attempt < MAX_RETRIES - 1:
-            delay = BASE_DELAY * (2 ** attempt)
+            delay = BASE_DELAY * (2**attempt)
             print(f"Retrying in {delay}s...")
             time.sleep(delay)
 


### PR DESCRIPTION
### Description

add retries. 

### Test Plan

Use the raw url of the file to test in a local ctl-api and deploy. interrupted the ctl-api runner api. ensure @ least 5 retries are attempted (ngrok or funnel logs). 

### Note
in the case of 5 failures, total time spent will be 35s.

```bash
python -c 'print(sum([(1.75 ** i) for i in range(1,6)]))'
35.9638671875
```

```bash
python -c 'print([(1.75 ** i) for i in range(1,6)])'
[1.75, 3.0625, 5.359375, 9.37890625, 16.4130859375]
```
We can consider 1.95 too but that's just splitting hairs.