### PR TITLE
chore: add a timeout to the http.request in the phonehome lambda

### DIFF
--- a/scripts/aws/phonehome.py
+++ b/scripts/aws/phonehome.py
@@ -30,6 +30,7 @@ def lambda_handler(event, context):
                 "POST",
                 url,
                 body=encoded_data,
+                timeout=5,
                 headers={"Content-Type": "application/json"},
             )
             if 200 <= response.status < 300:


### PR DESCRIPTION
otherwise, if the api is down, the phone home will wait indefinitely for
a response that is destined to never arrive. this is really only an
issue in dev when the runner api may be down. in production, we expect a
sub second response and no more than 1 failure at any given time.

#machineassisted (barely)
https://ampcode.com/threads/T-019c2728-c452-7034-81d1-234d7310f9a6
