### PR TITLE
fix: add StartLimitIntervalSec=0 to systemd services

### DIFF
--- a/scripts/aws/init-mng.sh
+++ b/scripts/aws/init-mng.sh
@@ -187,6 +187,7 @@ Environment="GIT_REF=latest"
 ExecStart=/opt/nuon/runner/bin/runner mng
 Restart=always
 RestartSec=3
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=default.target

--- a/scripts/aws/init.sh
+++ b/scripts/aws/init.sh
@@ -86,6 +86,7 @@ ExecStopPost=-/bin/sh -c "/usr/bin/docker rmi  $(/usr/bin/docker images -a -q)"
 ExecStopPost=-/bin/sh -c "yes | /usr/bin/docker system prune"
 Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
- Adds `StartLimitIntervalSec=0` to both init.sh and init-mng.sh systemd service definitions

## Test plan
- [ ] Verify new instances get unlimited restart policy