### PR TITLE
chore(aws): use new endpoint to fetch binary version

### DIFF
--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -114,6 +114,22 @@ RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-latest}"
 
 
 #
+# Determine Runner Binary Version
+#
+echo "determining runner binary version"
+echo " > $RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings"
+for i in $(seq 1 30); do
+  runner_binary_version=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings" | jq -r '.binary_version')
+  if [ -n "$runner_binary_version" ] && [ "$runner_binary_version" != "null" ]; then
+    RUNNER_BINARY_VERSION="$runner_binary_version"
+    echo "determined runner binary version: $RUNNER_BINARY_VERSION"
+    break
+  fi
+  echo "attempt $i/30: failed to determine runner binary version, retrying in 2s"
+  sleep 2
+done
+
+#
 # install runner binary (tag: latest always)
 #
 curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/runner/install.sh > /tmp/install-runner.sh


### PR DESCRIPTION
### Description

Use the runner api public-settings endpoint to fetch the binary version. 