### PR TITLE
chore: fail fast if the RUNNER_BINARY_VERSION is not provided

### DIFF
--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -110,7 +110,11 @@ RUNNER_API_URL=$(get_tag "nuon_runner_api_url")
 # env var: defaults but over-written by env_vars block in runner.toml
 RUNNER_ID=$(get_tag "nuon_runner_id")
 RUNNER_AUTH_METHOD="${RUNNER_AUTH_METHOD:-sts}"
-RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-latest}"
+
+# the runner binary version should never fall back to latest.
+# if no value is provided (via runner.toml) leave it empty
+# attempt to retreive from URL and shut down if that fails.
+RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 
 #
@@ -128,6 +132,12 @@ for i in $(seq 1 30); do
   echo "attempt $i/30: failed to determine runner binary version, retrying in 2s"
   sleep 2
 done
+
+if [ -z "$RUNNER_BINARY_VERSION" ]; then
+  echo "No runner binary version provided and could not determined from Nuon Runner API - shutting down"
+  /sbin/shutdown -h now "nuon-runner-mng could not determine RUNNER_BINARY_VERSION"
+  exit 1
+fi
 
 #
 # install runner binary (tag: latest always)

--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -140,7 +140,7 @@ if [ -z "$RUNNER_BINARY_VERSION" ]; then
 fi
 
 #
-# install runner binary (tag: latest always)
+# install runner binary (tag: RUNNER_BINARY_VERSION)
 #
 curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/runner/install.sh > /tmp/install-runner.sh
 chmod +x /tmp/install-runner.sh
@@ -183,6 +183,7 @@ RUNNER_API_URL=$RUNNER_API_URL
 RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD
 AWS_REGION=$AWS_REGION
 HOST_IP=$(curl -s https://checkip.amazonaws.com)
+GIT_REF=$CONTAINER_IMAGE_URL
 EOF
 
 cat << EOF > /opt/nuon/runner/image
@@ -244,7 +245,6 @@ User=runner
 EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
 EnvironmentFile=/opt/nuon/runner/token
-Environment="GIT_REF=latest"
 ExecStart=/opt/nuon/runner/bin/runner mng
 Restart=always
 RestartSec=3

--- a/scripts/aws/init-mng.sh
+++ b/scripts/aws/init-mng.sh
@@ -110,7 +110,11 @@ RUNNER_API_URL=$(get_tag "nuon_runner_api_url")
 # env var: defaults but over-written by env_vars block in runner.toml
 RUNNER_ID=$(get_tag "nuon_runner_id")
 RUNNER_AUTH_METHOD="${RUNNER_AUTH_METHOD:-sts}"
-RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-latest}"
+
+# the runner binary version should never fall back to latest.
+# if no value is provided (via runner.toml) leave it empty
+# attempt to retreive from URL and shut down if that fails.
+RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 
 #
@@ -128,6 +132,12 @@ for i in $(seq 1 30); do
   echo "attempt $i/30: failed to determine runner binary version, retrying in 2s"
   sleep 2
 done
+
+if [ -z "$RUNNER_BINARY_VERSION" ]; then
+  echo "No runner binary version provided and could not determined from Nuon Runner API - shutting down"
+  /sbin/shutdown -h now "nuon-runner-mng could not determine RUNNER_BINARY_VERSION"
+  exit 1
+fi
 
 #
 # install runner binary (tag: latest always)

--- a/scripts/aws/init-mng.sh
+++ b/scripts/aws/init-mng.sh
@@ -140,7 +140,7 @@ if [ -z "$RUNNER_BINARY_VERSION" ]; then
 fi
 
 #
-# install runner binary (tag: latest always)
+# install runner binary (tag: RUNNER_BINARY_VERSION)
 #
 curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/runner/install.sh > /tmp/install-runner.sh
 chmod +x /tmp/install-runner.sh
@@ -183,6 +183,7 @@ RUNNER_API_URL=$RUNNER_API_URL
 RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD
 AWS_REGION=$AWS_REGION
 HOST_IP=$(curl -s https://checkip.amazonaws.com)
+GIT_REF=$CONTAINER_IMAGE_URL
 EOF
 
 cat << EOF > /opt/nuon/runner/image
@@ -244,7 +245,6 @@ User=runner
 EnvironmentFile=/opt/nuon/runner/image
 EnvironmentFile=/opt/nuon/runner/env
 EnvironmentFile=/opt/nuon/runner/token
-Environment="GIT_REF=latest"
 ExecStart=/opt/nuon/runner/bin/runner mng
 Restart=always
 RestartSec=3


### PR DESCRIPTION
### Description

The RUNNER_BINARY_VERSION's source of truth is the runner api. If we are unable to retrieve a value, we prefer to fail fast..

The failure case will lead to a VM shutdown. The RunnerASG will stand up a fresh instance and try again.
