### PR TITLE
feat(gcp): bump init timeout from 5m to 15m

### DIFF
--- a/scripts/gcp/init-mng-v2.sh
+++ b/scripts/gcp/init-mng-v2.sh
@@ -18,10 +18,10 @@
 # once we have confirmed the runner mng service is healthy. nohup + disown
 # ensure the timer survives cloud-init script cleanup.
 #
-nohup bash -c 'sleep 300; /sbin/shutdown -h now "nuon-runner-mng userdata 5m hard deadline expired"' </dev/null >/dev/null 2>&1 &
+nohup bash -c 'sleep 900; /sbin/shutdown -h now "nuon-runner-mng userdata 15m hard deadline expired"' </dev/null >/dev/null 2>&1 &
 SHUTDOWN_PID=$!
 disown "$SHUTDOWN_PID" 2>/dev/null || true
-echo "scheduled hard-deadline shutdown in 5m with pid=$SHUTDOWN_PID"
+echo "scheduled hard-deadline shutdown in 15m with pid=$SHUTDOWN_PID"
 
 #
 # install dependencies
@@ -264,7 +264,7 @@ CONSECUTIVE_HEALTHY=0
 REQUIRED_CONSECUTIVE=3
 MIN_UPTIME_SEC=60
 
-for i in $(seq 1 20); do
+for i in $(seq 1 60); do
     ACTIVE_STATE=$(systemctl show nuon-runner-mng --property=ActiveState --value)
     SUB_STATE=$(systemctl show nuon-runner-mng --property=SubState --value)
     N_RESTARTS=$(systemctl show nuon-runner-mng --property=NRestarts --value)
@@ -280,14 +280,14 @@ for i in $(seq 1 20); do
 
     if [ "$ACTIVE_STATE" = "active" ] && [ "$SUB_STATE" = "running" ] && [ "$UPTIME_SEC" -ge "$MIN_UPTIME_SEC" ]; then
         CONSECUTIVE_HEALTHY=$((CONSECUTIVE_HEALTHY + 1))
-        echo "nuon-runner-mng stable ($CONSECUTIVE_HEALTHY/$REQUIRED_CONSECUTIVE consecutive): uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/20)"
+        echo "nuon-runner-mng stable ($CONSECUTIVE_HEALTHY/$REQUIRED_CONSECUTIVE consecutive): uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/60)"
         if [ "$CONSECUTIVE_HEALTHY" -ge "$REQUIRED_CONSECUTIVE" ]; then
             HEALTHY=true
             break
         fi
     else
         CONSECUTIVE_HEALTHY=0
-        echo "nuon-runner-mng not stable: state=$ACTIVE_STATE/$SUB_STATE uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/20)"
+        echo "nuon-runner-mng not stable: state=$ACTIVE_STATE/$SUB_STATE uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/60)"
     fi
 
     sleep 15

--- a/scripts/gcp/init.sh
+++ b/scripts/gcp/init.sh
@@ -18,10 +18,10 @@
 # once we have confirmed the runner mng service is healthy. nohup + disown
 # ensure the timer survives cloud-init script cleanup.
 #
-nohup bash -c 'sleep 300; /sbin/shutdown -h now "nuon-runner-mng userdata 5m hard deadline expired"' </dev/null >/dev/null 2>&1 &
+nohup bash -c 'sleep 900; /sbin/shutdown -h now "nuon-runner-mng userdata 15m hard deadline expired"' </dev/null >/dev/null 2>&1 &
 SHUTDOWN_PID=$!
 disown "$SHUTDOWN_PID" 2>/dev/null || true
-echo "scheduled hard-deadline shutdown in 5m with pid=$SHUTDOWN_PID"
+echo "scheduled hard-deadline shutdown in 15m with pid=$SHUTDOWN_PID"
 
 #
 # install dependencies
@@ -264,7 +264,7 @@ CONSECUTIVE_HEALTHY=0
 REQUIRED_CONSECUTIVE=3
 MIN_UPTIME_SEC=60
 
-for i in $(seq 1 20); do
+for i in $(seq 1 60); do
     ACTIVE_STATE=$(systemctl show nuon-runner-mng --property=ActiveState --value)
     SUB_STATE=$(systemctl show nuon-runner-mng --property=SubState --value)
     N_RESTARTS=$(systemctl show nuon-runner-mng --property=NRestarts --value)
@@ -280,14 +280,14 @@ for i in $(seq 1 20); do
 
     if [ "$ACTIVE_STATE" = "active" ] && [ "$SUB_STATE" = "running" ] && [ "$UPTIME_SEC" -ge "$MIN_UPTIME_SEC" ]; then
         CONSECUTIVE_HEALTHY=$((CONSECUTIVE_HEALTHY + 1))
-        echo "nuon-runner-mng stable ($CONSECUTIVE_HEALTHY/$REQUIRED_CONSECUTIVE consecutive): uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/20)"
+        echo "nuon-runner-mng stable ($CONSECUTIVE_HEALTHY/$REQUIRED_CONSECUTIVE consecutive): uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/60)"
         if [ "$CONSECUTIVE_HEALTHY" -ge "$REQUIRED_CONSECUTIVE" ]; then
             HEALTHY=true
             break
         fi
     else
         CONSECUTIVE_HEALTHY=0
-        echo "nuon-runner-mng not stable: state=$ACTIVE_STATE/$SUB_STATE uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/20)"
+        echo "nuon-runner-mng not stable: state=$ACTIVE_STATE/$SUB_STATE uptime=${UPTIME_SEC}s restarts=$N_RESTARTS (attempt $i/60)"
     fi
 
     sleep 15


### PR DESCRIPTION
We were seeing GCP take longer to stand up the runner instance in some cases, resulting in sometimes 4 MIG cycles before the runner stabilized in time. 

Here we bump the deadman switch timeout from 5m to 15m. 