### PR TITLE
feat: override RUNNER_API_URL from public settings

### DIFF
--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -118,20 +118,28 @@ RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 
 #
-# Determine Runner Binary Version
+# Fetch public settings (binary version + runner API URL override)
 #
-echo "determining runner binary version"
+echo "fetching public settings"
 echo " > $RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings"
+PUBLIC_SETTINGS=""
 for i in $(seq 1 30); do
-  runner_binary_version=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings" | jq -r '.binary_version')
-  if [ -n "$runner_binary_version" ] && [ "$runner_binary_version" != "null" ]; then
+  PUBLIC_SETTINGS=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings")
+  runner_binary_version=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
+  if [ -n "$runner_binary_version" ]; then
     RUNNER_BINARY_VERSION="$runner_binary_version"
     echo "determined runner binary version: $RUNNER_BINARY_VERSION"
     break
   fi
-  echo "attempt $i/30: failed to determine runner binary version, retrying in 2s"
+  echo "attempt $i/30: failed to fetch public settings, retrying in 2s"
   sleep 2
 done
+
+runner_api_url_override=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url_override" ]; then
+  echo "overriding RUNNER_API_URL from public settings: $runner_api_url_override"
+  RUNNER_API_URL="$runner_api_url_override"
+fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determined from Nuon Runner API - shutting down"

--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -106,6 +106,7 @@ get_tag() {
 }
 
 RUNNER_API_URL=$(get_tag "nuon_runner_api_url")
+BOOTSTRAP_API_URL="$RUNNER_API_URL"
 
 # env var: defaults but over-written by env_vars block in runner.toml
 RUNNER_ID=$(get_tag "nuon_runner_id")
@@ -137,10 +138,6 @@ RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empt
 echo "runner binary version: $RUNNER_BINARY_VERSION"
 
 runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
-if [ -n "$runner_api_url" ]; then
-  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
-  RUNNER_API_URL="$runner_api_url"
-fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determined from Nuon Runner API - shutting down"
@@ -161,12 +158,18 @@ rm /tmp/install-runner.sh
 #
 chown -R runner:runner /opt/nuon/runner
 
-# run mng fetch-token with the runner api url (retry indefinitely every 15s until success)
-echo "running mng fetch-token with RUNNER_API_URL=$RUNNER_API_URL RUNNER_ID=$RUNNER_ID RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD"
-while ! sudo -u runner RUNNER_API_URL="$RUNNER_API_URL" RUNNER_ID="$RUNNER_ID" RUNNER_AUTH_METHOD="$RUNNER_AUTH_METHOD" ./opt/nuon/runner/bin/runner mng fetch-token; do
+# run mng fetch-token using the bootstrap URL so the GCP identity token audience matches
+echo "running mng fetch-token with RUNNER_API_URL=$BOOTSTRAP_API_URL RUNNER_ID=$RUNNER_ID RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD"
+while ! sudo -u runner RUNNER_API_URL="$BOOTSTRAP_API_URL" RUNNER_ID="$RUNNER_ID" RUNNER_AUTH_METHOD="$RUNNER_AUTH_METHOD" ./opt/nuon/runner/bin/runner mng fetch-token; do
   echo "mng fetch-token failed, retrying in 15s"
   sleep 15
 done
+
+# apply the runner API URL override after auth — the runner process uses this for all ongoing calls
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
+fi
 
 
 #

--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -118,27 +118,28 @@ RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 
 #
-# Fetch public settings (binary version + runner API URL override)
+# Fetch public settings
 #
 echo "fetching public settings"
 echo " > $RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings"
 PUBLIC_SETTINGS=""
 for i in $(seq 1 30); do
   PUBLIC_SETTINGS=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings")
-  runner_binary_version=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
-  if [ -n "$runner_binary_version" ]; then
-    RUNNER_BINARY_VERSION="$runner_binary_version"
-    echo "determined runner binary version: $RUNNER_BINARY_VERSION"
+  if [ -n "$PUBLIC_SETTINGS" ] && [ "$PUBLIC_SETTINGS" != "null" ]; then
+    echo "fetched public settings (attempt $i)"
     break
   fi
   echo "attempt $i/30: failed to fetch public settings, retrying in 2s"
   sleep 2
 done
 
-runner_api_url_override=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
-if [ -n "$runner_api_url_override" ]; then
-  echo "overriding RUNNER_API_URL from public settings: $runner_api_url_override"
-  RUNNER_API_URL="$runner_api_url_override"
+RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
+echo "runner binary version: $RUNNER_BINARY_VERSION"
+
+runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
 fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then

--- a/scripts/aws/init-mng-v2.sh
+++ b/scripts/aws/init-mng-v2.sh
@@ -106,7 +106,6 @@ get_tag() {
 }
 
 RUNNER_API_URL=$(get_tag "nuon_runner_api_url")
-BOOTSTRAP_API_URL="$RUNNER_API_URL"
 
 # env var: defaults but over-written by env_vars block in runner.toml
 RUNNER_ID=$(get_tag "nuon_runner_id")
@@ -138,6 +137,10 @@ RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empt
 echo "runner binary version: $RUNNER_BINARY_VERSION"
 
 runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
+fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determined from Nuon Runner API - shutting down"
@@ -158,18 +161,12 @@ rm /tmp/install-runner.sh
 #
 chown -R runner:runner /opt/nuon/runner
 
-# run mng fetch-token using the bootstrap URL so the GCP identity token audience matches
-echo "running mng fetch-token with RUNNER_API_URL=$BOOTSTRAP_API_URL RUNNER_ID=$RUNNER_ID RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD"
-while ! sudo -u runner RUNNER_API_URL="$BOOTSTRAP_API_URL" RUNNER_ID="$RUNNER_ID" RUNNER_AUTH_METHOD="$RUNNER_AUTH_METHOD" ./opt/nuon/runner/bin/runner mng fetch-token; do
+# run mng fetch-token with the runner api url (retry indefinitely every 15s until success)
+echo "running mng fetch-token with RUNNER_API_URL=$RUNNER_API_URL RUNNER_ID=$RUNNER_ID RUNNER_AUTH_METHOD=$RUNNER_AUTH_METHOD"
+while ! sudo -u runner RUNNER_API_URL="$RUNNER_API_URL" RUNNER_ID="$RUNNER_ID" RUNNER_AUTH_METHOD="$RUNNER_AUTH_METHOD" ./opt/nuon/runner/bin/runner mng fetch-token; do
   echo "mng fetch-token failed, retrying in 15s"
   sleep 15
 done
-
-# apply the runner API URL override after auth — the runner process uses this for all ongoing calls
-if [ -n "$runner_api_url" ]; then
-  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
-  RUNNER_API_URL="$runner_api_url"
-fi
 
 
 #

--- a/scripts/gcp/init-mng-v2.sh
+++ b/scripts/gcp/init-mng-v2.sh
@@ -106,7 +106,6 @@ get_metadata() {
 }
 
 RUNNER_API_URL=${NUON_RUNNER_API_URL:-$(get_metadata "nuon_runner_api_url")}
-BOOTSTRAP_API_URL="$RUNNER_API_URL"
 RUNNER_ID=${NUON_RUNNER_ID:-$(get_metadata "nuon_runner_id")}
 
 # the runner binary version should never fall back to latest.
@@ -134,6 +133,10 @@ RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empt
 echo "runner binary version: $RUNNER_BINARY_VERSION"
 
 runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
+fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determine from Nuon Runner API - shutting down"
@@ -156,17 +159,11 @@ rm /tmp/install-runner.sh
 
 chown -R runner:runner /opt/nuon/runner
 
-# run mng fetch-token using the bootstrap URL so the GCP identity token audience matches
-while ! sudo -u runner RUNNER_API_URL="$BOOTSTRAP_API_URL" CLOUD_PROVIDER=gcp /opt/nuon/runner/bin/runner mng fetch-token; do
+# run mng fetch-token with the runner api url (retry indefinitely every 15s until success)
+while ! sudo -u runner RUNNER_API_URL="$RUNNER_API_URL" CLOUD_PROVIDER=gcp /opt/nuon/runner/bin/runner mng fetch-token; do
   echo "mng fetch-token failed, retrying in 15s"
   sleep 15
 done
-
-# apply the runner API URL override after auth — the runner process uses this for all ongoing calls
-if [ -n "$runner_api_url" ]; then
-  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
-  RUNNER_API_URL="$runner_api_url"
-fi
 
 #
 # gather more facts

--- a/scripts/gcp/init-mng-v2.sh
+++ b/scripts/gcp/init-mng-v2.sh
@@ -114,27 +114,28 @@ RUNNER_ID=${NUON_RUNNER_ID:-$(get_metadata "nuon_runner_id")}
 RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 #
-# Fetch public settings (binary version + runner API URL override)
+# Fetch public settings
 #
 echo "fetching public settings"
 echo " > $RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings"
 PUBLIC_SETTINGS=""
 for i in $(seq 1 30); do
   PUBLIC_SETTINGS=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings")
-  runner_binary_version=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
-  if [ -n "$runner_binary_version" ]; then
-    RUNNER_BINARY_VERSION="$runner_binary_version"
-    echo "determined runner binary version: $RUNNER_BINARY_VERSION"
+  if [ -n "$PUBLIC_SETTINGS" ] && [ "$PUBLIC_SETTINGS" != "null" ]; then
+    echo "fetched public settings (attempt $i)"
     break
   fi
   echo "attempt $i/30: failed to fetch public settings, retrying in 2s"
   sleep 2
 done
 
-runner_api_url_override=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
-if [ -n "$runner_api_url_override" ]; then
-  echo "overriding RUNNER_API_URL from public settings: $runner_api_url_override"
-  RUNNER_API_URL="$runner_api_url_override"
+RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
+echo "runner binary version: $RUNNER_BINARY_VERSION"
+
+runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
 fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then

--- a/scripts/gcp/init-mng-v2.sh
+++ b/scripts/gcp/init-mng-v2.sh
@@ -114,20 +114,28 @@ RUNNER_ID=${NUON_RUNNER_ID:-$(get_metadata "nuon_runner_id")}
 RUNNER_BINARY_VERSION="${RUNNER_BINARY_VERSION:-}"
 
 #
-# Determine Runner Binary Version
+# Fetch public settings (binary version + runner API URL override)
 #
-echo "determining runner binary version"
+echo "fetching public settings"
 echo " > $RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings"
+PUBLIC_SETTINGS=""
 for i in $(seq 1 30); do
-  runner_binary_version=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings" | jq -r '.binary_version')
-  if [ -n "$runner_binary_version" ] && [ "$runner_binary_version" != "null" ]; then
+  PUBLIC_SETTINGS=$(curl -s "$RUNNER_API_URL/v1/runners/$RUNNER_ID/public-settings")
+  runner_binary_version=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empty')
+  if [ -n "$runner_binary_version" ]; then
     RUNNER_BINARY_VERSION="$runner_binary_version"
     echo "determined runner binary version: $RUNNER_BINARY_VERSION"
     break
   fi
-  echo "attempt $i/30: failed to determine runner binary version, retrying in 2s"
+  echo "attempt $i/30: failed to fetch public settings, retrying in 2s"
   sleep 2
 done
+
+runner_api_url_override=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
+if [ -n "$runner_api_url_override" ]; then
+  echo "overriding RUNNER_API_URL from public settings: $runner_api_url_override"
+  RUNNER_API_URL="$runner_api_url_override"
+fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determine from Nuon Runner API - shutting down"

--- a/scripts/gcp/init-mng-v2.sh
+++ b/scripts/gcp/init-mng-v2.sh
@@ -106,6 +106,7 @@ get_metadata() {
 }
 
 RUNNER_API_URL=${NUON_RUNNER_API_URL:-$(get_metadata "nuon_runner_api_url")}
+BOOTSTRAP_API_URL="$RUNNER_API_URL"
 RUNNER_ID=${NUON_RUNNER_ID:-$(get_metadata "nuon_runner_id")}
 
 # the runner binary version should never fall back to latest.
@@ -133,10 +134,6 @@ RUNNER_BINARY_VERSION=$(echo "$PUBLIC_SETTINGS" | jq -r '.binary_version // empt
 echo "runner binary version: $RUNNER_BINARY_VERSION"
 
 runner_api_url=$(echo "$PUBLIC_SETTINGS" | jq -r '.runner_api_url // empty')
-if [ -n "$runner_api_url" ]; then
-  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
-  RUNNER_API_URL="$runner_api_url"
-fi
 
 if [ -z "$RUNNER_BINARY_VERSION" ]; then
   echo "No runner binary version provided and could not determine from Nuon Runner API - shutting down"
@@ -159,11 +156,17 @@ rm /tmp/install-runner.sh
 
 chown -R runner:runner /opt/nuon/runner
 
-# run mng fetch-token with the runner api url (retry indefinitely every 15s until success)
-while ! sudo -u runner RUNNER_API_URL="$RUNNER_API_URL" CLOUD_PROVIDER=gcp /opt/nuon/runner/bin/runner mng fetch-token; do
+# run mng fetch-token using the bootstrap URL so the GCP identity token audience matches
+while ! sudo -u runner RUNNER_API_URL="$BOOTSTRAP_API_URL" CLOUD_PROVIDER=gcp /opt/nuon/runner/bin/runner mng fetch-token; do
   echo "mng fetch-token failed, retrying in 15s"
   sleep 15
 done
+
+# apply the runner API URL override after auth — the runner process uses this for all ongoing calls
+if [ -n "$runner_api_url" ]; then
+  echo "setting RUNNER_API_URL from public settings: $runner_api_url"
+  RUNNER_API_URL="$runner_api_url"
+fi
 
 #
 # gather more facts


### PR DESCRIPTION
Init scripts now fetch public-settings once and extract both fields cleanly.

- single retry loop fetches the full PUBLIC_SETTINGS response
- `binary_version` and `runner_api_url` extracted in separate blocks after the loop
- if `runner_api_url` is set, it overrides the bootstrapped metadata URL — runner binary makes all subsequent calls through the customer's proxy